### PR TITLE
Remove output preview

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1,6 +1,6 @@
-nextflow.enable.dsl=2
-
-nextflow.preview.output = true
+//
+// Nextflow pipeline for peptide identification with multiple search engines and post-processing tools
+//
 
 // default python image
 params.python_image = 'ghcr.io/medbioinf/pipeline-of-identification:latest'
@@ -30,6 +30,7 @@ params.execute_sage = true
 params.execute_xtandem = true
 
 // default parameter files
+params.outdir = './'
 params.comet_params_file = "${baseDir}/config/comet.params"
 params.maxquant_params_file = "${baseDir}/config/mqpar.xml"
 params.msamanda_config_file = "${baseDir}/config/msamanda_settings.xml"
@@ -177,11 +178,6 @@ workflow {
 }
 
 output {
-    'mzmls' {
-        enabled params.keep_mzmls
-        path 'mzmls'
-    }
-
     'comet' {
         enabled params.execute_comet
         path 'comet'

--- a/main.nf
+++ b/main.nf
@@ -86,7 +86,11 @@ workflow {
     }
 
     if (params.raw_files) {
-        raw_files = Channel.fromPath(params.raw_files).flatten()
+        if (params.is_timstof) {
+            raw_files = Channel.fromPath(params.raw_files, type: 'dir').flatten()
+        } else {
+            raw_files = Channel.fromPath(params.raw_files).flatten()
+        }
         raw_files_info = raw_files
     } else {
         raw_files_info = "no raw spectra given"

--- a/main.nf
+++ b/main.nf
@@ -148,7 +148,7 @@ workflow {
 
     if (params.execute_maxquant) {
         maxquant_params_file = Channel.fromPath(params.maxquant_params_file).first()
-        maxquant_identification(maxquant_params_file, fasta_target, mzmls, params.precursor_tol_ppm)
+        maxquant_identification(maxquant_params_file, fasta_target, raw_files, mzmls, params.precursor_tol_ppm)
     }
 
     if (params.execute_msamanda) {

--- a/main.nf
+++ b/main.nf
@@ -176,35 +176,3 @@ workflow {
         xtandem_identification(xtandem_config_file, fasta_target_decoy, mzmls, params.precursor_tol_ppm, params.fragment_tol_da)
     }
 }
-
-output {
-    'maxquant' {
-        enabled params.execute_maxquant
-        path 'maxquant'
-    }
-
-    'msamanda' {
-        enabled params.execute_msamanda
-        path 'msamanda'
-    }
-
-    'msfragger' {
-        enabled params.execute_msfragger
-        path 'msfragger'
-    }
-
-    'msgfplus' {
-        enabled params.execute_msgfplus
-        path 'msgfplus'
-    }
-
-    'sage' {
-        enabled params.execute_sage
-        path 'sage'
-    }
-
-    'xtandem' {
-        enabled params.execute_xtandem
-        path 'xtandem'
-    }
-}

--- a/main.nf
+++ b/main.nf
@@ -178,11 +178,6 @@ workflow {
 }
 
 output {
-    'comet' {
-        enabled params.execute_comet
-        path 'comet'
-    }
-
     'maxquant' {
         enabled params.execute_maxquant
         path 'maxquant'

--- a/src/identification/comet_identification.nf
+++ b/src/identification/comet_identification.nf
@@ -36,25 +36,15 @@ workflow comet_identification {
     psm_tsvs = psm_tsvs_and_pin.psm_tsv
     pin_files = psm_tsvs_and_pin.pin_file
 
-    pout_files = psm_percolator(pin_files)
+    psm_percolator(pin_files, 'comet')
 
     psm_tsvs_and_mzmls = psm_tsvs.map { it -> [ it.name, it.name.take(it.name.lastIndexOf('.mzid')) + '.mzML'  ] }
-    ms2rescore_pins = ms2rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.comet_psm_id_pattern, params.comet_spectrum_id_pattern, '^DECOY_', 'comet')
-    oktoberfest_pins = oktoberfest_rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.comet_scan_id_pattern)
+    ms2rescore_pins = ms2rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.comet_spectrum_id_pattern, 'comet')
+    oktoberfest_pins = oktoberfest_rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.comet_scan_id_pattern, 'comet')
     
     // perform percolation
-    ms2rescore_percolator_results = ms2rescore_percolator(ms2rescore_pins.ms2rescore_pins)
-    oktoberfest_percolator_results = oktoberfest_percolator(oktoberfest_pins.oktoberfest_pins)
-
-    publish:
-    comet_mzids >> 'comet'
-    psm_tsvs >> 'comet'
-    pin_files >> 'comet'
-    pout_files >> 'comet'
-    ms2rescore_pins >> 'comet'
-    ms2rescore_percolator_results >> 'comet'
-    oktoberfest_pins >> 'comet'
-    oktoberfest_percolator_results >> 'comet'
+    ms2rescore_percolator(ms2rescore_pins.ms2rescore_pins, 'comet')
+    oktoberfest_percolator(oktoberfest_pins.oktoberfest_pins, 'comet')
 }
 
 
@@ -98,6 +88,8 @@ process identification_with_comet {
     cpus { params.comet_threads }
     memory { params.comet_mem }
     container { params.comet_image }
+
+	publishDir "${params.outdir}/comet", mode: 'copy'
 
     input:
     path fasta

--- a/src/identification/maxquant_identification.nf
+++ b/src/identification/maxquant_identification.nf
@@ -41,7 +41,7 @@ workflow maxquant_identification {
     psm_tsvs = psm_tsvs_and_pin.psm_tsv
     pin_files = psm_tsvs_and_pin.pin_file
 
-    pout_files = psm_percolator(pin_files)
+    psm_percolator(pin_files, 'maxquant')
 
     if (params.maxquant_psm_id_pattern) {
         psm_id_pattern = params.maxquant_psm_id_pattern
@@ -75,22 +75,12 @@ workflow maxquant_identification {
         psm_tsvs_and_spectra_oktoberfest = psm_tsvs_and_spectrafiles
     }
 
-    ms2rescore_pins = ms2rescore_workflow(psm_tsvs_and_spectrafiles, psm_tsvs.collect(), process_files.collect(), psm_id_pattern, spectrum_id_pattern, '', 'maxquant')
-    oktoberfest_pins = oktoberfest_rescore_workflow(psm_tsvs_and_spectra_oktoberfest, psm_tsvs.collect(), mzmls.collect(), scan_id_pattern)
+    ms2rescore_pins = ms2rescore_workflow(psm_tsvs_and_spectrafiles, psm_tsvs.collect(), process_files.collect(), spectrum_id_pattern, 'maxquant')
+    oktoberfest_pins = oktoberfest_rescore_workflow(psm_tsvs_and_spectra_oktoberfest, psm_tsvs.collect(), mzmls.collect(), scan_id_pattern, 'maxquant')
     
     // perform percolation
-    ms2rescore_percolator_results = ms2rescore_percolator(ms2rescore_pins.ms2rescore_pins)
-    oktoberfest_percolator_results = oktoberfest_percolator(oktoberfest_pins.oktoberfest_pins)
-
-    publish:
-    maxquant_results >> 'maxquant'
-    psm_tsvs >> 'maxquant'
-    pin_files >> 'maxquant'
-    pout_files >> 'maxquant'
-    ms2rescore_pins >> 'maxquant'
-    ms2rescore_percolator_results >> 'maxquant'
-    oktoberfest_pins >> 'maxquant'
-    oktoberfest_percolator_results >> 'maxquant'
+    ms2rescore_percolator(ms2rescore_pins.ms2rescore_pins, 'maxquant')
+    oktoberfest_percolator(oktoberfest_pins.oktoberfest_pins, 'maxquant')
 }
 
 
@@ -99,8 +89,10 @@ process identification_with_maxquant {
     memory { params.maxquant_mem }
     container { params.maxquant_image }
 
+    publishDir "${params.outdir}/maxquant", mode: 'copy'
+
     stageInMode 'copy'  // MaxQuant respectively Mono does not support symlinks
-    
+
     input:
     path maxquant_params_file
     path fasta

--- a/src/identification/maxquant_identification.nf
+++ b/src/identification/maxquant_identification.nf
@@ -24,13 +24,14 @@ workflow maxquant_identification {
     take:
     maxquant_params_file
     fasta
+    raw_files
     mzmls
     precursor_tol_ppm
 
     main:
     // for TimsTOF data, always process the .d path instead of the mzML files
     if (params.is_timstof) {
-        process_files = Channel.fromPath(params.raw_files).flatten()
+        process_files = raw_files
     } else {
         process_files = mzmls
     }

--- a/src/identification/msamanda_identification.nf
+++ b/src/identification/msamanda_identification.nf
@@ -41,25 +41,15 @@ workflow msamanda_identification {
     psm_tsvs = psm_tsvs_and_pin.psm_tsv
     pin_files = psm_tsvs_and_pin.pin_file
 
-    pout_files = psm_percolator(pin_files)
+    psm_percolator(pin_files, 'msamanda')
 
     psm_tsvs_and_mzmls = psm_tsvs.map { it -> [ it.name, it.name.take(it.name.lastIndexOf('_msamanda.csv')) + '.mzML'  ] }
-    ms2rescore_pins = ms2rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.msamanda_psm_id_pattern, params.msamanda_spectrum_id_pattern, '^DECOY_', 'msamanda')
-    oktoberfest_pins = oktoberfest_rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.msamanda_scan_id_pattern)
+    ms2rescore_pins = ms2rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.msamanda_spectrum_id_pattern, 'msamanda')
+    oktoberfest_pins = oktoberfest_rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.msamanda_scan_id_pattern, 'msamanda')
 
     // perform percolation
-    ms2rescore_percolator_results = ms2rescore_percolator(ms2rescore_pins.ms2rescore_pins)
-    oktoberfest_percolator_results = oktoberfest_percolator(oktoberfest_pins.oktoberfest_pins)
-
-    publish:
-    msamanda_results.msamanda_csv >> 'msamanda'
-    psm_tsvs >> 'msamanda'
-    pin_files >> 'msamanda'
-    pout_files >> 'msamanda'
-    ms2rescore_pins >> 'msamanda'
-    ms2rescore_percolator_results >> 'msamanda'
-    oktoberfest_pins >> 'msamanda'
-    oktoberfest_percolator_results >> 'msamanda'
+    ms2rescore_percolator(ms2rescore_pins.ms2rescore_pins, 'msamanda')
+    oktoberfest_percolator(oktoberfest_pins.oktoberfest_pins, 'msamanda')
 }
 
 
@@ -67,6 +57,8 @@ process identification_with_msamanda {
     cpus { params.msamanda_threads }
     memory { params.msamanda_mem }
     container { params.msamanda_image }
+
+    publishDir "${params.outdir}/msamanda", mode: 'copy'
 
     input:
     path msamanda_config_file

--- a/src/identification/msfragger_identification.nf
+++ b/src/identification/msfragger_identification.nf
@@ -35,25 +35,15 @@ workflow msfragger_identification {
     psm_tsvs = psm_tsvs_and_pin.psm_tsv
     pin_files = psm_tsvs_and_pin.pin_file
 
-    pout_files = psm_percolator(pin_files)
+    psm_percolator(pin_files, 'msfragger')
 
     psm_tsvs_and_mzmls = psm_tsvs.map { it -> [ it.name, it.name.take(it.name.lastIndexOf('.pepXML')) + '.mzML'  ] }
-    ms2rescore_pins = ms2rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.msfragger_psm_id_pattern, params.msfragger_spectrum_id_pattern, '^DECOY_', 'msfragger')
-    oktoberfest_pins = oktoberfest_rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.msfragger_scan_id_pattern)
+    ms2rescore_pins = ms2rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.msfragger_spectrum_id_pattern, 'msfragger')
+    oktoberfest_pins = oktoberfest_rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.msfragger_scan_id_pattern, 'msfragger')
     
     // perform percolation
-    ms2rescore_percolator_results = ms2rescore_percolator(ms2rescore_pins.ms2rescore_pins)
-    oktoberfest_percolator_results = oktoberfest_percolator(oktoberfest_pins.oktoberfest_pins)
-
-    publish:
-    fragger_results_pepxml >> 'msfragger'
-    psm_tsvs >> 'msfragger'
-    pin_files >> 'msfragger'
-    pout_files >> 'msfragger'
-    ms2rescore_pins >> 'msfragger'
-    ms2rescore_percolator_results >> 'msfragger'
-    oktoberfest_pins >> 'msfragger'
-    oktoberfest_percolator_results >> 'msfragger'
+    ms2rescore_percolator(ms2rescore_pins.ms2rescore_pins, 'msfragger')
+    oktoberfest_percolator(oktoberfest_pins.oktoberfest_pins, 'msfragger')
 }
 
 
@@ -100,6 +90,8 @@ process identification_with_msfragger {
     cpus { params.msfragger_threads }
     memory { params.msfragger_mem_gb + " GB" }
     container { params.msfragger_image }
+    
+    publishDir "${params.outdir}/msfragger", mode: 'copy'
 
     input:
     path fasta

--- a/src/identification/msgfplus_identification.nf
+++ b/src/identification/msgfplus_identification.nf
@@ -105,7 +105,7 @@ process identification_with_msgfplus {
     memory { params.msgfplus_mem_gb + " GB" }
     container { params.msgfplus_image }
 
-    publishDir "${params.outdir}/msgfplus", mode: 'copy', enabled: publish_results
+    publishDir "${params.outdir}/msgfplus", mode: 'copy', enabled: { publish_results }
 
     input:
     path msgfplus_params_file

--- a/src/identification/xtandem_identification.nf
+++ b/src/identification/xtandem_identification.nf
@@ -37,25 +37,15 @@ workflow xtandem_identification {
     psm_tsvs = psm_tsvs_and_pin.psm_tsv
     pin_files = psm_tsvs_and_pin.pin_file
 
-    pout_files = psm_percolator(pin_files)
+    psm_percolator(pin_files, 'xtandem')
 
     psm_tsvs_and_mzmls = psm_tsvs.map { it -> [ it.name, it.name.take(it.name.lastIndexOf('.xtandem_identification')) + '.mzML'  ] }
-    ms2rescore_pins = ms2rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.xtandem_psm_id_pattern, params.xtandem_spectrum_id_pattern, '^DECOY_', 'xtandem')
-    oktoberfest_pins = oktoberfest_rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.xtandem_scan_id_pattern)
-    
+    ms2rescore_pins = ms2rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.xtandem_spectrum_id_pattern, 'xtandem')
+    oktoberfest_pins = oktoberfest_rescore_workflow(psm_tsvs_and_mzmls, psm_tsvs.collect(), mzmls.collect(), params.xtandem_scan_id_pattern, 'xtandem')
+
     // perform percolation
-    ms2rescore_percolator_results = ms2rescore_percolator(ms2rescore_pins.ms2rescore_pins)
-    oktoberfest_percolator_results = oktoberfest_percolator(oktoberfest_pins.oktoberfest_pins)
-    
-    publish:
-    tandem_xmls >> 'xtandem'
-    psm_tsvs >> 'xtandem'
-    pin_files >> 'xtandem'
-    pout_files >> 'xtandem'
-    ms2rescore_pins >> 'xtandem'
-    ms2rescore_percolator_results >> 'xtandem'
-    oktoberfest_pins >> 'xtandem'
-    oktoberfest_percolator_results >> 'xtandem'
+    ms2rescore_percolator(ms2rescore_pins.ms2rescore_pins, 'xtandem')
+    oktoberfest_percolator(oktoberfest_pins.oktoberfest_pins, 'xtandem')
 }
 
 /**
@@ -127,6 +117,8 @@ process identification_with_xtandem {
     cpus { params.xtandem_threads }
     memory { params.xtandem_mem }
     container { params.xtandem_image }
+    
+    publishDir "${params.outdir}/xtandem", mode: 'copy'
 
     input:
     path xtandem_param_file

--- a/src/postprocessing/convert_and_enhance_psm_tsv.nf
+++ b/src/postprocessing/convert_and_enhance_psm_tsv.nf
@@ -93,6 +93,8 @@ process enhance_psms_and_create_pin {
     memory { params.enhance_psm_tsv_mem }
     container { params.python_image }
 
+	publishDir "${params.outdir}/${searchengine}", mode: 'copy'
+
     input:
     path psm_utils_tsv
     val searchengine

--- a/src/postprocessing/ms2rescore.nf
+++ b/src/postprocessing/ms2rescore.nf
@@ -11,14 +11,12 @@ workflow ms2rescore_workflow {
     psm_tsvs_and_mzmls
     psm_tsvs
     mzmls
-    psm_id_pattern
     spectrum_id_pattern
-    id_decoy_pattern
     searchengine
 
     main:
     ms2rescore_pre_pins = run_chunked_ms2rescore(psm_tsvs_and_mzmls, psm_tsvs, mzmls, spectrum_id_pattern, params.fragment_tol_da)
-    ms2rescore_pins = correct_psm_utils_pins(ms2rescore_pre_pins)
+    ms2rescore_pins = correct_psm_utils_pins(ms2rescore_pre_pins, searchengine)
 
     emit:
     ms2rescore_pins
@@ -62,8 +60,11 @@ process correct_psm_utils_pins {
 
     container { params.python_image }
 
+	publishDir "${params.outdir}/${searchengine}", mode: 'copy'
+
     input:
     path psm_utils_pins
+    val searchengine
 
     output:
     path "${psm_utils_pins.baseName}.corrected.pin"

--- a/src/postprocessing/oktoberfest.nf
+++ b/src/postprocessing/oktoberfest.nf
@@ -22,10 +22,11 @@ workflow oktoberfest_rescore_workflow {
     psm_tsvs
     mzmls
     scan_id_regex
+    searchengine
 
     main:
     oktoberfest_features = run_oktoberfest_feature_gen(psm_tsvs_and_mzmls, psm_tsvs, mzmls, params.fragment_tol_da, scan_id_regex)
-    oktoberfest_pins = oktoberfest_features_to_pin(oktoberfest_features)
+    oktoberfest_pins = oktoberfest_features_to_pin(oktoberfest_features, searchengine)
 
 
     emit:
@@ -88,8 +89,11 @@ process oktoberfest_features_to_pin {
 
     container { params.oktoberfest_image }
 
+	publishDir "${params.outdir}/${searchengine}", mode: 'copy'
+
     input:
     path okt_features_tsv
+    val searchengine
 
     output:
     path "${okt_features_tsv.baseName}.oktoberfest.pin"

--- a/src/postprocessing/percolator.nf
+++ b/src/postprocessing/percolator.nf
@@ -14,9 +14,10 @@ params.percolator_mem = "4 GB"
 workflow psm_percolator {
     take:
     pin_files
+    searchengine
 
     main:
-    pout_files = run_percolator(pin_files)
+    pout_files = run_percolator(pin_files, searchengine)
 
     emit:
     pout_files
@@ -28,8 +29,11 @@ process run_percolator {
     memory { params.percolator_mem }
     container { params.percolator_image }
 
+	publishDir "${params.outdir}/${searchengine}", mode: 'copy'
+
     input:
     path pin_file
+    val searchengine
 
     output:
     path "${pin_file.baseName}.pout"

--- a/src/preprocess/convert_to_mzml.nf
+++ b/src/preprocess/convert_to_mzml.nf
@@ -18,15 +18,14 @@ workflow convert_to_mzml {
         
     emit:
     mzml
-
-    publish:
-    mzml >> 'mzmls'
 }
 
 process convert_thermo_raw {
     cpus 2
     memory "8 GB"
     container { params.msconvert_image }
+
+	publishDir "${params.outdir}/mzmls", mode: 'copy', enabled: params.keep_mzmls
 
     input:
     path input_raw
@@ -65,6 +64,8 @@ process adjust_mzML {
     cpus 2
     memory "8 GB"
     container { params.msconvert_image }
+
+	publishDir "${params.outdir}/mzmls", mode: 'copy', enabled: params.keep_mzmls
 
     input:
     path input_mzML


### PR DESCRIPTION
Using the established `publishDir` instead of the `output`, which is under preview